### PR TITLE
Add shared workflow for triaging issue

### DIFF
--- a/.github/workflows/move-issue-to-project-and-set-fields.md
+++ b/.github/workflows/move-issue-to-project-and-set-fields.md
@@ -1,0 +1,40 @@
+# Triage issues by label
+### Adds an issue to project and sets the field and field option given a specific label
+
+The purpose of this workflow is to help teams triage issues within the context of GitHub Projects. At a high level, this workflow will:
+
+- Be triggered when an issue receives a specific label
+- Add the issue to a GitHub Project
+- Categorize the issue by the field and field option specified from the [caller workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows#example-caller-workflow).
+
+It is built as a [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows) (also referred to as a called workflow) so that it can be used by repositories outside of this one with one of the biggest incentives being to **automate the triage process** when issues are opened in a repository.
+
+With the combination of this action and creating issue templates that add default labels to issues, teams can automatically have issues be added to their respective GitHub Project and filter those issues into the appropriate field/area of the project for _single select_ fields.
+
+## Required inputs / secrets
+
+### Inputs
+
+- `field`: This is the name of the field category the issue will be moved to.
+- `field_option`: This is the name of the field option/value the issue will be assigned.
+- `project_number`: This is the project number the issue will be added to.
+
+### Secrets
+
+- `token`: A personal access token (PAT) must be provided from the caller workflow to the called workflow. This token must have both the `repo` and `project` scope.
+
+### Example usage
+
+```yml
+move-ts-issues:
+  if: ${{ github.event.label.name == 'TypeScript' }}
+  uses: carbon-design-system/.github/.github/workflows/move-issue-to-project-and-set-fields.yml
+  with:
+    field: 'Area'
+    field_option: '🟦 Typescript'
+    project_number: '1'
+  secrets:
+    token: ${{ secrets.TOKEN }}
+```
+
+This workflow will work if an issue has already been added to a project and can move an issue within the same field as long as a valid `field_option` is provided. If the `field_option` input is not included or blank, the action will fail and the issue will not be assigned a field within the project.

--- a/.github/workflows/move-issue-to-project-and-set-fields.md
+++ b/.github/workflows/move-issue-to-project-and-set-fields.md
@@ -25,16 +25,25 @@ With the combination of this action and creating issue templates that add defaul
 
 ### Example usage
 
+As this workflow is meant to be used when an issue receives a label, the [`issue` event type](https://docs.github.com/en/rest/using-the-rest-api/issue-event-types?apiVersion=2022-11-28#labeled) should be used.
+
 ```yml
-move-ts-issues:
-  if: ${{ github.event.label.name == 'TypeScript' }}
-  uses: carbon-design-system/.github/.github/workflows/move-issue-to-project-and-set-fields.yml
-  with:
-    field: 'Area'
-    field_option: '🟦 Typescript'
-    project_number: '1'
-  secrets:
-    token: ${{ secrets.TOKEN }}
+name: Caller workflow example for triaging issues
+
+on:
+  issues:
+    types: [ labeled ]
+
+jobs:
+  move-ts-issues:
+    if: ${{ github.event.label.name == 'TypeScript' }}
+    uses: carbon-design-system/.github/.github/workflows/move-issue-to-project-and-set-fields.yml
+    with:
+      field: 'Area'
+      field_option: '🟦 Typescript'
+      project_number: '1'
+    secrets:
+      token: ${{ secrets.TOKEN }}
 ```
 
 This workflow will work if an issue has already been added to a project and can move an issue within the same field as long as a valid `field_option` is provided. If the `field_option` input is not included or blank, the action will fail and the issue will not be assigned a field within the project.

--- a/.github/workflows/move-issue-to-project-and-set-fields.yml
+++ b/.github/workflows/move-issue-to-project-and-set-fields.yml
@@ -14,6 +14,9 @@ on:
         default: ''
         type: string
         required: true
+    secrets:
+      token:
+        required: true
 
 jobs:
   move_to_project_field:
@@ -21,7 +24,7 @@ jobs:
     steps:
       - name: Get project data
         env:
-          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_SET_FIELD }}
+          GH_TOKEN: ${{ secrets.token }}
         run: |
           gh api graphql -f query='
           query($org: String!, $number: Int!) {
@@ -55,7 +58,7 @@ jobs:
 
       - name: Add issue to project
         env:
-          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_SET_FIELD }}
+          GH_TOKEN: ${{ secrets.token }}
           ISSUE_ID: ${{ github.event.issue.node_id }}
         # Uses [GitHub CLI](https://cli.github.com/manual/) and the API to add the issue that triggered this workflow to the project. The `jq` flag parses the response to get the ID of the created item.
         run: |
@@ -72,7 +75,7 @@ jobs:
 
       - name: Set field value
         env:
-          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_SET_FIELD }}
+          GH_TOKEN: ${{ secrets.token }}
         # Sets the value of the `field` to the specified `field_option`.
         run: |
           gh api graphql -f query='

--- a/.github/workflows/move-issue-to-project-and-set-fields.yml
+++ b/.github/workflows/move-issue-to-project-and-set-fields.yml
@@ -1,0 +1,97 @@
+name: Add issue to project and set field and field option given a specific label
+on:
+  workflow_call:
+    inputs:
+      field:
+        default: ''
+        type: string
+        required: true
+      field_option:
+        default: ''
+        type: string
+        required: true
+      project_number:
+        default: ''
+        type: string
+        required: true
+
+jobs:
+  move_to_project_field:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get project data
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_SET_FIELD }}
+        run: |
+          gh api graphql -f query='
+          query($org: String!, $number: Int!) {
+            organization(login: $org){
+              projectV2(number: $number) {
+                id
+                fields(first:20) {
+                  nodes {
+                    ... on ProjectV2Field {
+                      id
+                      name
+                    }
+                    ... on ProjectV2SingleSelectField {
+                      id
+                      name
+                      options {
+                        id
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }' -f org=${{ github.repository_owner }} -F number=${{ inputs.project_number }} > project_data.json
+
+          echo 'Field and field option are: "${{ inputs.field }}: ${{ inputs.field_option }}"'
+          echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
+          echo 'FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name=="${{ inputs.field }}") | .id' project_data.json) >> $GITHUB_ENV
+          echo 'FIELD_OPTION_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name=="${{ inputs.field }}") | .options[] | select(.name=="${{ inputs.field_option }}") |.id' project_data.json) >> $GITHUB_ENV
+
+      - name: Add issue to project
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_SET_FIELD }}
+          ISSUE_ID: ${{ github.event.issue.node_id }}
+        # Uses [GitHub CLI](https://cli.github.com/manual/) and the API to add the issue that triggered this workflow to the project. The `jq` flag parses the response to get the ID of the created item.
+        run: |
+          item_id="$( gh api graphql -f query='
+            mutation($project:ID!, $issue:ID!) {
+              addProjectV2ItemById(input: {projectId: $project, contentId: $issue}) {
+                item {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectV2ItemById.item.id')"
+
+            echo 'ITEM_ID='$item_id >> $GITHUB_ENV
+
+      - name: Set field value
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_SET_FIELD }}
+        # Sets the value of the `field` to the specified `field_option`.
+        run: |
+          gh api graphql -f query='
+            mutation (
+              $project: ID!
+              $item: ID!
+              $field_id: ID!
+              $field_option: String!
+            ) {
+              set_field: updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $field_id
+                value: {
+                  singleSelectOptionId: $field_option
+                  }
+              }) {
+                projectV2Item {
+                  id
+                  }
+              }
+            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f field_id=$FIELD_ID -f field_option=${{ env.FIELD_OPTION_ID }} --silent


### PR DESCRIPTION
@tay1orjones suggested this could be a good place to house shared workflows for teams within our github org. This kicks things off with a reusable workflow initially created [here](https://github.com/carbon-design-system/ibm-products/pull/4872), so that it can be used by other teams. It will add an issue to a given project and set the provided field and field value. We found this to be valuable when triaging issues, for example issues labeled "area: typescript" will be moved into the "Area: 🟦 TypeScript" field in our project.

I previously used `secrets: inherit` from the calling workflow and that _should_ work given that this repo is within the same github org based on the docs [here](https://docs.github.com/en/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow).

> Workflows that call reusable workflows in the same organization or enterprise can use the inherit keyword to implicitly pass the secrets.

However, that assumed that any team using this workflow had their secret named exactly as `ADD_TO_PROJECT_SET_FIELD`. Whereas with the current change, you can have your token named whatever you like and just pass it in.

To see how this workflow would be used, [see here for an example](https://github.com/carbon-design-system/ibm-products/blob/main/.github/workflows/triage-labeled-issues.yml). And [here is an example](https://github.com/matthewgallo/ibm-products-vite-template/blob/main/.github/workflows/move-issues-to-project-area.yml#L8-L16) of what it would look like given the updated change to the `secret`.